### PR TITLE
Fix for CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')

### DIFF
--- a/sqli/dao/student.py
+++ b/sqli/dao/student.py
@@ -39,9 +39,8 @@ class Student(NamedTuple):
 
     @staticmethod
     async def create(conn: Connection, name: str):
-        q = ("INSERT INTO students (name) "
-             "VALUES ('%(name)s')" % {'name': name})
+        q = "INSERT INTO students (name) VALUES (%s)"
         async with conn.cursor() as cur:
-            await cur.execute(q)
+            await cur.execute(q, (name,))
 
 


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in sqli/dao/student.py.

It is CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') that has a severity of High.

### 🪄 Fix explanation
The fix mitigates SQL injection by using parameterized queries, replacing string interpolation with placeholders and passing user input as parameters, ensuring inputs are treated as data, not executable SQL.
<bullet>Replaced string interpolation with parameterized query using <code>%s</code> as a placeholder in the SQL statement.</bullet>
    <bullet>Modified <code>await cur.execute(q)</code> to <code>await cur.execute(q, (name,))</code> to pass user input as a parameter.</bullet>
    <bullet>This change ensures that the input <code>name</code> is safely handled by the database driver, preventing SQL injection.</bullet>

[See the issue and fix in Corgea.](https://1200-2a09-bac1-76a0-c98-00-26b-62.ngrok-free.app/issue/dbd5640f-2e5d-43ed-be96-77ab314c4401)

