### PR TITLE
Fix for CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag

### DIFF
--- a/sqli/middlewares.py
+++ b/sqli/middlewares.py
@@ -17,7 +17,7 @@ async def session_middleware(request, handler):
     # middleware factory. Do not forget to await on results here as original
     # session middleware factory is also awaitable.
     app = request.app
-    storage = RedisStorage(app['redis'], httponly=False)
+    storage = RedisStorage(app['redis'], httponly=True)
     middleware = session_middleware_(storage)
     return await middleware(request, handler)
 


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in sqli/middlewares.py.

It is CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag that has a severity of Medium.

### 🪄 Fix explanation
The fix sets the 'HttpOnly' flag to 'True' for cookies, preventing client-side scripts from accessing sensitive cookie data, thus mitigating the risk of XSS attacks.
- The code change occurs in <code>middlewares.py</code>, line 20.
    - The <code>httponly</code> parameter in <code>RedisStorage</code> is changed from <code>False</code> to <code>True</code>.
    - This change ensures cookies are inaccessible to client-side scripts, enhancing security.

[See the issue and fix in Corgea.](https://doghouse.corgeainternal.dev/issue/05433fbb-f769-4ede-9c21-e30d99da575e)

