### PR TITLE
Fix for CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')

### DIFF
--- a/sqli/dao/student.py
+++ b/sqli/dao/student.py
@@ -40,8 +40,9 @@ class Student(NamedTuple):
     @staticmethod
     async def create(conn: Connection, name: str):
         q = ("INSERT INTO students (name) "
-             "VALUES ('%(name)s')" % {'name': name})
+             "VALUES (%(name)s)")
+        params = {'name': name}
         async with conn.cursor() as cur:
-            await cur.execute(q)
+            await cur.execute(q, params)
 
 


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in sqli/dao/student.py.

It is CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') that has a severity of High.

### 🪄 Fix explanation
The fix mitigates SQL injection by using parameterized queries, which separate SQL logic from user input, preventing malicious input from altering the SQL command structure.
<bullet>Replaced string interpolation with parameterized query by removing <code>'%(name)s'</code> and using <code>%(name)s</code> as a placeholder.</bullet>
    <bullet>Introduced a <code>params</code> dictionary to safely pass user input to the query.</bullet>
    <bullet>Modified <code>await cur.execute(q)</code> to <code>await cur.execute(q, params)</code> to bind parameters securely.</bullet>

[See the issue and fix in Corgea.](https://1c0e-2a09-bac1-76a0-c98-00-1bf-8d.ngrok-free.app/issue/fac29ec1-4751-4cc0-8776-6355a07e0c44)

