### PR TITLE
Fix for CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')

### DIFF
--- a/sqli/dao/student.py
+++ b/sqli/dao/student.py
@@ -40,8 +40,8 @@ class Student(NamedTuple):
     @staticmethod
     async def create(conn: Connection, name: str):
         q = ("INSERT INTO students (name) "
-             "VALUES ('%(name)s')" % {'name': name})
+             "VALUES (%(name)s)")
         async with conn.cursor() as cur:
-            await cur.execute(q)
+            await cur.execute(q, {'name': name})
 
 


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in sqli/dao/student.py.

It is CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') that has a severity of High.

### 🪄 Fix explanation
The fix mitigates SQL injection by using parameterized queries, replacing string interpolation with a parameterized placeholder to safely insert user input into the SQL command.
- Replaced string interpolation <code>"VALUES ('%(name)s')" % {'name': name}</code> with a parameterized query <code>"VALUES (%(name)s)"</code>.
    - Used <code>await cur.execute(q, {'name': name})</code> to pass parameters safely, preventing SQL injection.
    - The parameterized query ensures user input is treated as data, not executable SQL.

[See the issue and fix in Corgea.](https://doghouse.corgeainternal.dev/issue/647ad2d1-34fa-4fab-ab68-ea3d73e86b23)

