### PR TITLE
Fix for CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')

### DIFF
--- a/sqli/dao/student.py
+++ b/sqli/dao/student.py
@@ -40,8 +40,9 @@ class Student(NamedTuple):
     @staticmethod
     async def create(conn: Connection, name: str):
         q = ("INSERT INTO students (name) "
-             "VALUES ('%(name)s')" % {'name': name})
+             "VALUES (%(name)s)")
+        params = {'name': name}
         async with conn.cursor() as cur:
-            await cur.execute(q)
+            await cur.execute(q, params)
 
 


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in sqli/dao/student.py.

It is CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') that has a severity of High.

### 🪄 Fix explanation
The fix mitigates SQL injection by using parameterized queries, which separate SQL logic from user input, preventing malicious input from altering the SQL command.
<bullet_point>
        The SQL query now uses a parameterized placeholder <code>%(name)s</code> instead of directly embedding user input.
    </bullet_point>
    <bullet_point>
        A dictionary <code>params</code> is created to safely pass user input to the query, ensuring it is treated as data.
    </bullet_point>
    <bullet_point>
        The <code>execute</code> method now takes the query and <code>params</code> separately, preventing SQL injection.
    </bullet_point>

[See the issue and fix in Corgea.](https://www.corgea.app/issue/2e9a0835-b025-4f99-acb2-f690bab689dc)

